### PR TITLE
TLS証明書が正常に読み込めないのを修正

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -37,11 +37,14 @@ useExpressServer(app, {
     development: false,
 });
 
+const TLS_KEY = process.env.TLS_KEY_PATH ? readFileSync(process.env.TLS_KEY_PATH) : process.env.TLS_KEY;
+const TLS_CERT = process.env.TLS_CERT_PATH ? readFileSync(process.env.TLS_CERT_PATH) : process.env.TLS_CERT;
+
 // https
 const tlsServer = createServer(
     {
-        key: readFileSync(process.env.TLS_KEY || ''),
-        cert: readFileSync(process.env.TLS_CERT || ''),
+        key: TLS_KEY,
+        cert: TLS_CERT,
     },
     app
 );

--- a/src/app.ts
+++ b/src/app.ts
@@ -37,8 +37,17 @@ useExpressServer(app, {
     development: false,
 });
 
-const TLS_KEY = process.env.TLS_KEY_PATH ? readFileSync(process.env.TLS_KEY_PATH) : process.env.TLS_KEY;
-const TLS_CERT = process.env.TLS_CERT_PATH ? readFileSync(process.env.TLS_CERT_PATH) : process.env.TLS_CERT;
+const TLS_KEY = process.env.TLS_KEY_PATH
+    ? readFileSync(process.env.TLS_KEY_PATH)
+    : process.env.TLS_KEY
+    ? process.env.TLS_KEY.replace(/\\n/g, '\n')
+    : '';
+
+const TLS_CERT = process.env.TLS_CERT_PATH
+    ? readFileSync(process.env.TLS_CERT_PATH)
+    : process.env.TLS_CERT
+    ? process.env.TLS_CERT.replace(/\\n/g, '\n')
+    : '';
 
 // https
 const tlsServer = createServer(


### PR DESCRIPTION
GCPの環境変数が1行でしか読み込めないので、エスケープ文字に置換した